### PR TITLE
Refactor: Update VintageCarMarketplace.sol

### DIFF
--- a/smart-contracts/contracts/VintageCarMarketplace.sol
+++ b/smart-contracts/contracts/VintageCarMarketplace.sol
@@ -109,11 +109,6 @@ contract VintageCarMarketplace is
       
         _createListing(tokenId, startingPrice, ListingType.Auction);
 
-        vintageCarNFT.transferFrom(
-            msg.sender,
-            address(auctionContract),
-            tokenId
-        );
         auctionContract.createAuction(
             tokenId,
             startingPrice,

--- a/smart-contracts/contracts/VintageCarMarketplace.sol
+++ b/smart-contracts/contracts/VintageCarMarketplace.sol
@@ -16,12 +16,13 @@ interface INFTAuction {
         uint256 _nftId,
         uint256 _startingPrice,
         uint256 _buyoutPrice,
-        uint256 _duration
+        uint256 _duration,
+        address _nftOwner
     ) external;
 
     function endAuction(uint256 _nftId) external;
 
-    function cancelAuction(uint256 _nftId) external;
+    function cancelAuction(uint256 _nftId, address _nftOwner) external;
 }
 
 contract VintageCarMarketplace is
@@ -117,7 +118,8 @@ contract VintageCarMarketplace is
             tokenId,
             startingPrice,
             buyoutPrice,
-            duration
+            duration,
+            msg.sender
         );
 
         emit AuctionCreated(tokenId, startingPrice, buyoutPrice, duration);
@@ -177,7 +179,7 @@ contract VintageCarMarketplace is
                 address(auctionContract) != address(0),
                 "Auction contract not set"
             );
-            auctionContract.cancelAuction(tokenId);
+            auctionContract.cancelAuction(tokenId, msg.sender);
         }
 
         listing.isActive = false;


### PR DESCRIPTION
- Removed ICarVerificationOracle: Since the NFT contract now handles the verification, we don't need to interact with the verification oracle directly in the marketplace.

- Updated IVintageCarNFT interface: Removed isApprovedOrOwner and getCarDetails functions, added getTokenIdByVIN function.

Constructor: Removed the _carVerificationOracle parameter as it's no longer needed.

- _createListing function: Replaced isApprovedOrOwner check with a direct ownerOf check.

- Removed all references to getCarDetails and carVerificationOracle.transferOwnership: They are no longer needed since the NFT transfer implies ownership transfer.

- updateContractAddresses function: Removed the _carVerificationOracle parameter.